### PR TITLE
fix: build preview modal and used zustand to manage state and persistence

### DIFF
--- a/components/modal-component/ConditionModal.tsx
+++ b/components/modal-component/ConditionModal.tsx
@@ -1,6 +1,7 @@
 "use client";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { HiCheck } from "react-icons/hi";
+import { useEscrowStore } from "@/store/useEscrowStore";
 
 interface ModalProps {
   onNext?: () => void;
@@ -8,21 +9,39 @@ interface ModalProps {
 }
 
 const ConditionModal: React.FC<ModalProps> = ({ onNext, onPrevious }) => {
-  const [selectedMilestone, setSelectedMilestone] = useState("");
+  const {
+    conditions,
+    selectedCondition,
+    customCondition,
+    setSelectedCondition,
+    setCustomCondition,
+    completeStep
+  } = useEscrowStore();
+  
+  const [localSelectedCondition, setLocalSelectedCondition] = useState(selectedCondition);
+  const [localCustomCondition, setLocalCustomCondition] = useState(customCondition);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isFormValid, setIsFormValid] = useState(false);
+  
+  // Validate form
+  useEffect(() => {
+    setIsFormValid(!!localSelectedCondition);
+  }, [localSelectedCondition]);
 
-  const milestones = [
-    {
-      title: "Manual approval by both parties.",
-    },
-    {
-      title: "Automatic release upon milestone completion.",
-    },
-  ];
-  const [stateMilestones, setStateMilestones] = useState(milestones);
-  const handleMilestoneClick = (title: string) => {
-    setSelectedMilestone(title);
+  const handleConditionClick = (title: string) => {
+    setLocalSelectedCondition(title);
     setIsDropdownOpen(false);
+  };
+  
+  const handleNext = () => {
+    if (!isFormValid) return;
+    
+    // Save data to store
+    setSelectedCondition(localSelectedCondition);
+    setCustomCondition(localCustomCondition);
+    completeStep('condition');
+    
+    if (onNext) onNext();
   };
 
   return (
@@ -53,13 +72,14 @@ const ConditionModal: React.FC<ModalProps> = ({ onNext, onPrevious }) => {
 
           {/* Condition */}
           <div className="flex items-center">
-            <div className="w-6 h-6 flex items-center justify-center bg-[#2D0561] rounded-full">
-              <HiCheck className="text-white text-lg" />
-            </div>
-            <div className="mt-12 -ml-10">
-              <span className="text-[#958F8F] font-medium text-[12px]">
-                Condition
-              </span>
+            <div className="w-6 h-6 flex items-center justify-center border-2 border-[#2D0561] rounded-full">
+              <div className="w-2 h-2 bg-[#2D0561] rounded-full">
+                <div className="mt-4 -ml-8">
+                  <span className="text-[#958F8F] font-medium text-[12px]">
+                    Condition
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
 
@@ -71,7 +91,7 @@ const ConditionModal: React.FC<ModalProps> = ({ onNext, onPrevious }) => {
               <div className="w-6 h-6 flex items-center justify-center bg-gray-300 rounded-full">
                 <div className="mt-12 ">
                   <span className="text-[#958F8F] font-medium text-[12px]">
-                    Preview
+                    Payment
                   </span>
                 </div>
               </div>
@@ -95,7 +115,6 @@ const ConditionModal: React.FC<ModalProps> = ({ onNext, onPrevious }) => {
         {/* Form */}
         <div className="p-6 space-y-2">
           <div className="mb-6">
-            {" "}
             <label
               htmlFor="release-condition"
               className="block text-sm font-[500] text-gray-700"
@@ -107,28 +126,28 @@ const ConditionModal: React.FC<ModalProps> = ({ onNext, onPrevious }) => {
                 onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                 className="w-full border border-[#D9D9D9] rounded-md shadow-sm pl-4 pr-8 py-2 text-left focus:ring-[#D9D9D9] focus:border-[#D9D9D9] sm:text-sm bg-white"
               >
-                {selectedMilestone || "Select release condition"}
+                {localSelectedCondition || "Select release condition"}
                 <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
                   ▼
                 </span>
               </button>
               {isDropdownOpen && (
                 <ul className="absolute z-10 mt-1 w-full bg-white shadow-lg rounded-md border border-[#D9D9D9]">
-                  {stateMilestones.map((milestone, index) => (
+                  {conditions.map((condition, index) => (
                     <li
                       key={index}
-                      onClick={() => handleMilestoneClick(milestone.title)}
+                      onClick={() => handleConditionClick(condition.title)}
                       className={`cursor-pointer px-4 py-2 hover:bg-purple-50 text-[14px] font-[500] flex items-start space-x-2 ${
-                        selectedMilestone === milestone.title
+                        localSelectedCondition === condition.title
                           ? "bg-purple-100 font-medium text-purple-700"
                           : "text-gray-700"
                       }`}
                     >
                       {/* Title */}
                       <div className="flex w-full justify-between items-center">
-                        <span className="font-medium">{milestone.title}</span>
+                        <span className="font-medium">{condition.title}</span>
 
-                        {selectedMilestone === milestone.title && (
+                        {localSelectedCondition === condition.title && (
                           <div className="flex">
                             <div className="w-6 h-6 flex items-center justify-center border-2 border-[#2D0561] rounded-full">
                               <div className="w-2 h-2 bg-[#2D0561] rounded-full"></div>
@@ -154,6 +173,8 @@ const ConditionModal: React.FC<ModalProps> = ({ onNext, onPrevious }) => {
             <textarea
               id="custom-condition"
               rows={3}
+              value={localCustomCondition}
+              onChange={(e) => setLocalCustomCondition(e.target.value)}
               className="mt-2 w-full border border-[#D9D9D9] rounded-md shadow-sm p-4 focus:ring-[#D9D9D9] focus:border-[#D9D9D9] sm:text-sm"
               placeholder="Enter custom conditions"
             />
@@ -172,8 +193,11 @@ const ConditionModal: React.FC<ModalProps> = ({ onNext, onPrevious }) => {
             Previous
           </button>
           <button
-            onClick={onNext}
-            className="px-6 py-2 w-[323px] h-[52px] bg-[#2D0561] text-white rounded-[4px] hover:bg-[#2d0561ee] focus:outline-none focus:ring-2 focus:ring-[#D9D9D9] focus:ring-offset-2"
+            onClick={handleNext}
+            disabled={!isFormValid}
+            className={`px-6 py-2 w-[323px] h-[52px] ${
+              isFormValid ? "bg-[#2D0561] hover:bg-[#2d0561ee]" : "bg-gray-400 cursor-not-allowed"
+            } text-white rounded-[4px] focus:outline-none focus:ring-2 focus:ring-[#D9D9D9] focus:ring-offset-2`}
           >
             Next
           </button>

--- a/components/modal-component/PaymentModal.tsx
+++ b/components/modal-component/PaymentModal.tsx
@@ -1,9 +1,9 @@
 "use client";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { HiCheck } from "react-icons/hi";
-import { GoDash } from "react-icons/go";
-import usdc from "@/public/images/usdc.svg";
 import Image from "next/image";
+import usdc from "@/public/images/usdc.svg";
+import { useEscrowStore } from "@/store/useEscrowStore";
 
 interface ModalProps {
   onNext?: () => void;
@@ -11,60 +11,39 @@ interface ModalProps {
 }
 
 const PaymentModal: React.FC<ModalProps> = ({ onNext, onPrevious }) => {
-  const [selectedMilestone, setSelectedMilestone] = useState("");
-  const [paymentAmount, setPaymentAmount] = useState("");
-  const [paymentPercentage, setPaymentPercentage] = useState("");
-  const [isMilestoneDropdownOpen, setIsMilestoneDropdownOpen] = useState(false);
-  const [isPaymentPercentageDropdownOpen, setIsPaymentPercentageDropdownOpen] =
-    useState(false);
+  const {
+    payments,
+    paymentAmount,
+    selectedPaymentStructure,
+    setPaymentAmount,
+    setSelectedPaymentStructure,
+    completeStep
+  } = useEscrowStore();
+  
+  const [localPaymentAmount, setLocalPaymentAmount] = useState(paymentAmount);
+  const [localSelectedPaymentStructure, setLocalSelectedPaymentStructure] = useState(selectedPaymentStructure);
+  const [isPaymentStructureDropdownOpen, setIsPaymentStructureDropdownOpen] = useState(false);
+  const [isFormValid, setIsFormValid] = useState(false);
+  
+  // Validate form
+  useEffect(() => {
+    setIsFormValid(!!localPaymentAmount && !!localSelectedPaymentStructure);
+  }, [localPaymentAmount, localSelectedPaymentStructure]);
 
-  const milestones = [
-    {
-      percentageBreakdown: [
-        { stage: "Initial Deposit Paid", percentage: 50 },
-        { stage: "First Draft Delivered", percentage: 25 },
-        { stage: "Revisions Completed", percentage: 15 },
-        { stage: "Final Delivery Approved", percentage: 10 },
-      ],
-    },
-    {
-      percentageBreakdown: [
-        { stage: "Initial Deposit Paid", percentage: 25 },
-        { stage: "First Draft Delivered", percentage: 25 },
-        { stage: "Revisions Completed", percentage: 25 },
-        { stage: "Final Delivery Approved", percentage: 25 },
-      ],
-    },
-    {
-      percentageBreakdown: [
-        { stage: "Initial Deposit Paid", percentage: 20 },
-        { stage: "First Draft Delivered", percentage: 20 },
-        { stage: "Revisions Completed", percentage: 20 },
-        { stage: "Final Delivery Approved", percentage: 40 },
-      ],
-    },
-  ];
-
-  const handleMilestoneClick = (index: number) => {
-    setSelectedMilestone(
-      milestones[index].percentageBreakdown
-        .map((p) => `${p.stage}: ${p.percentage}%`)
-        .join(" - ")
-    );
-    setIsMilestoneDropdownOpen(false);
+  const handlePaymentStructureClick = (paymentPercentageStructure: string) => {
+    setLocalSelectedPaymentStructure(paymentPercentageStructure);
+    setIsPaymentStructureDropdownOpen(false);
   };
 
-  const handlePaymentAmountChange = (amount: string) => {
-    setPaymentAmount(amount);
-  };
-
-  const handlePaymentPercentageChange = (index: number) => {
-    const selectedMilestoneBreakdown = milestones[index].percentageBreakdown
-      .map((p) => `${p.stage}: ${p.percentage}%`)
-      .join(" - ");
-
-    setPaymentPercentage(selectedMilestoneBreakdown);
-    setIsPaymentPercentageDropdownOpen(false);
+  const handleNext = () => {
+    if (!isFormValid) return;
+    
+    // Save data to store
+    setPaymentAmount(localPaymentAmount);
+    setSelectedPaymentStructure(localSelectedPaymentStructure);
+    completeStep('payment');
+    
+    if (onNext) onNext();
   };
 
   return (
@@ -136,48 +115,54 @@ const PaymentModal: React.FC<ModalProps> = ({ onNext, onPrevious }) => {
 
         {/* Form */}
         <div className="p-6 space-y-6">
-          {/* Milestone Dropdown */}
+          {/* Payment Structure Dropdown */}
           <div>
             <label
-              htmlFor="type-of-milestone"
+              htmlFor="payment-structure"
               className="block text-sm font-medium text-gray-700"
             >
               Milestone Payment Structure
             </label>
             <div className="relative mt-2">
               <button
-                onClick={() =>
-                  setIsMilestoneDropdownOpen(!isMilestoneDropdownOpen)
-                }
+                onClick={() => setIsPaymentStructureDropdownOpen(!isPaymentStructureDropdownOpen)}
                 className="w-full border border-[#D9D9D9] rounded-md shadow-sm pl-4 pr-8 py-2 text-left focus:ring-[#D9D9D9] focus:border-[#D9D9D9] sm:text-sm bg-white"
               >
-                {selectedMilestone || "Select milestone structure"}
+                {localSelectedPaymentStructure || "Select milestone structure"}
                 <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
                   ▼
                 </span>
               </button>
-              {isMilestoneDropdownOpen && (
+              {isPaymentStructureDropdownOpen && (
                 <ul className="absolute z-10 mt-1 w-full bg-white shadow-lg rounded-md border border-[#D9D9D9]">
-                  {milestones.map((milestone, index) => (
-                    <li
-                      key={index}
-                      onClick={() => handleMilestoneClick(index)}
-                      className={`cursor-pointer px-4 py-2 hover:bg-purple-50 text-[14px] font-[500] flex flex-col space-y-1 ${
-                        selectedMilestone ===
-                        milestone.percentageBreakdown
-                          .map((p) => `${p.stage}: ${p.percentage}%`)
-                          .join(" - ")
-                          ? "bg-purple-100 font-medium text-purple-700"
-                          : "text-gray-700"
-                      }`}
-                    >
-                      <div className="text-xs text-gray-600">
-                        {milestone.percentageBreakdown
-                          .map((p) => `${p.stage}: ${p.percentage}%`)
-                          .join(" - ")}
-                      </div>
-                    </li>
-                  ))}
+                  {payments.map((payment, index) => {
+                    const structureText = payment.percentageBreakdown
+                      .map((p) => `${p.stage}: ${p.percentage}%`)
+                      .join(" - ");
+                    
+                    return (
+                      <li
+                        key={index}
+                        onClick={() => handlePaymentStructureClick(structureText)}
+                        className={`cursor-pointer px-4 py-2 hover:bg-purple-50 text-[14px] font-[500] flex flex-col space-y-1 ${
+                          localSelectedPaymentStructure === structureText
+                            ? "bg-purple-100 font-medium text-purple-700"
+                            : "text-gray-700"
+                        }`}
+                      >
+                        <div className="text-xs text-gray-600">
+                          {structureText}
+                        </div>
+                        {localSelectedPaymentStructure === structureText && (
+                          <div className="flex justify-end">
+                            <div className="w-6 h-6 flex items-center justify-center border-2 border-[#2D0561] rounded-full">
+                              <div className="w-2 h-2 bg-[#2D0561] rounded-full"></div>
+                            </div>
+                          </div>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               )}
             </div>
@@ -196,9 +181,9 @@ const PaymentModal: React.FC<ModalProps> = ({ onNext, onPrevious }) => {
               <input
                 id="payment-amount"
                 type="text"
-                value={paymentAmount}
-                onChange={(e) => handlePaymentAmountChange(e.target.value)}
-                className="w-full border border-[#D9D9D9] rounded-md shadow-sm pl-4 pr-4 py-2 focus:ring-[#D9D9D9] focus:border-[#D9D9D9] sm:text-sm"
+                value={localPaymentAmount}
+                onChange={(e) => setLocalPaymentAmount(e.target.value)}
+                className="w-full border border-[#D9D9D9] rounded-md shadow-sm pl-4 pr-10 py-2 focus:ring-[#D9D9D9] focus:border-[#D9D9D9] sm:text-sm"
                 placeholder="Enter payment amount"
               />
               <div className="absolute inset-y-0 right-2 flex items-center pl-3">
@@ -211,55 +196,9 @@ const PaymentModal: React.FC<ModalProps> = ({ onNext, onPrevious }) => {
                 />
               </div>
             </div>
-          </div>
-
-          {/* Payment Percentage */}
-          <div>
-            <label
-              htmlFor="payment-percentage"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Payment Percentage
-            </label>
-            <div className="relative mt-2">
-              <button
-                onClick={() =>
-                  setIsPaymentPercentageDropdownOpen(
-                    !isPaymentPercentageDropdownOpen
-                  )
-                }
-                className="w-full border border-[#D9D9D9] rounded-md shadow-sm pl-4 pr-8 py-2 text-left focus:ring-[#D9D9D9] focus:border-[#D9D9D9] sm:text-sm bg-white"
-              >
-                {paymentPercentage || "Select milestone payment structure"}
-                <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                  ▼
-                </span>
-              </button>
-              {isPaymentPercentageDropdownOpen && (
-                <ul className="absolute z-10 mt-1 w-full bg-white shadow-lg rounded-md border border-[#D9D9D9]">
-                  {milestones.map((milestone, index) => (
-                    <li
-                      key={index}
-                      onClick={() => handlePaymentPercentageChange(index)}
-                      className={`cursor-pointer px-4 py-2 hover:bg-purple-50 text-[14px] font-[500] flex flex-col space-y-1 ${
-                        paymentPercentage ===
-                        milestone.percentageBreakdown
-                          .map((p) => `${p.stage}: ${p.percentage}%`)
-                          .join(" - ")
-                          ? "bg-purple-100 font-medium text-purple-700"
-                          : "text-gray-700"
-                      }`}
-                    >
-                      <div className="text-xs text-gray-600">
-                        {milestone.percentageBreakdown
-                          .map((p) => `${p.stage}: ${p.percentage}%`)
-                          .join(" - ")}
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
+            <p className="text-[12px] text-gray-500 mt-2">
+              Enter the total payment amount for this contract in USDC
+            </p>
           </div>
         </div>
 
@@ -272,8 +211,11 @@ const PaymentModal: React.FC<ModalProps> = ({ onNext, onPrevious }) => {
             Previous
           </button>
           <button
-            onClick={onNext}
-            className="px-6 py-2 w-[323px] h-[52px] bg-[#2D0561] text-white rounded-[4px] hover:bg-[#2d0561ee] focus:outline-none focus:ring-2 focus:ring-[#D9D9D9] focus:ring-offset-2"
+            onClick={handleNext}
+            disabled={!isFormValid}
+            className={`px-6 py-2 w-[323px] h-[52px] ${
+              isFormValid ? "bg-[#2D0561] hover:bg-[#2d0561ee]" : "bg-gray-400 cursor-not-allowed"
+            } text-white rounded-[4px] focus:outline-none focus:ring-2 focus:ring-[#D9D9D9] focus:ring-offset-2`}
           >
             Next
           </button>

--- a/components/modal-component/PreviewModal.tsx
+++ b/components/modal-component/PreviewModal.tsx
@@ -1,0 +1,183 @@
+"use client";
+import React from "react";
+import { FaXmark } from "react-icons/fa6";
+import { HiCheck } from "react-icons/hi";
+import { useEscrowStore } from "@/store/useEscrowStore";
+import Image from "next/image";
+import usdc from "@/public/images/usdc.svg";
+
+interface ModalProps {
+  onPrevious?: () => void;
+  closeModal?: () => void;
+}
+
+export default function PreviewModal({ onPrevious, closeModal }: ModalProps) {
+  let buyer = "0x74949...794";
+  let seller = "0x84839...854";
+  const { getEscrowData, completeStep, resetStore } = useEscrowStore();
+  const escrowData = getEscrowData();
+
+  // Handle confirmation
+  const handleConfirm = () => {
+    completeStep('preview');
+    resetStore();
+    if (closeModal) closeModal();
+  };
+
+  return (
+    <div className="fixed left-1/2 top-1/2 h-screen w-screen -ml-[50vw] -mt-[50vh] z-20 bg-gray-400/20 backdrop-blur-sm transition duration-400 flex items-center justify-center">
+      <div className="w-full max-w-3xl bg-white rounded-lg shadow-lg">
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-gray-300">
+          <div className="flex w-full justify-end">
+            <FaXmark className="cursor-pointer" onClick={closeModal} />
+          </div>
+          <h2 className="text-[16px] font-bold text-center text-gray-800">
+            Create Escrow Contract
+          </h2>
+        </div>
+
+        {/* Progress Bar */}
+        <div className="flex items-center justify-center px-6 py-4">
+          {/* Milestone */}
+          <div className="flex items-center">
+            <div className="w-6 h-6 flex items-center justify-center bg-[#2D0561] rounded-full">
+              <HiCheck className="text-white text-lg" />
+            </div>
+            <div className="mt-12 -ml-10">
+              <span className="text-[#958F8F] font-medium text-[12px]">
+                Milestone
+              </span>
+            </div>
+          </div>
+
+          <div className="-ml-4 w-20 h-px bg-[#2D0561]"></div>
+
+          {/* Condition */}
+          <div className="flex items-center">
+            <div className="w-6 h-6 flex items-center justify-center bg-[#2D0561] rounded-full">
+              <HiCheck className="text-white text-lg" />
+            </div>
+            <div className="mt-12 -ml-10">
+              <span className="text-[#958F8F] font-medium text-[12px]">
+                Condition
+              </span>
+            </div>
+          </div>
+
+          <div className="-ml-4 w-16 h-px bg-[#2D0561]"></div>
+
+          {/* Payment */}
+          <div className="flex items-center">
+            <div className="w-6 h-6 flex items-center justify-center bg-[#2D0561] rounded-full">
+              <HiCheck className="text-white text-lg" />
+            </div>
+            <div className="mt-12 -ml-10">
+              <span className="text-[#958F8F] font-medium text-[12px]">
+                Payment
+              </span>
+            </div>
+          </div>
+
+          <div className="-ml-2 w-16 h-px bg-[#2D0561]"></div>
+
+          {/* Preview */}
+          <div className="flex items-center">
+            <div className="w-6 h-6 flex items-center justify-center border-2 border-[#2D0561] rounded-full">
+              <div className="w-2 h-2 bg-[#2D0561] rounded-full">
+                <div className="mt-4 -ml-5">
+                  <span className="text-[#958F8F] font-medium text-[12px]">
+                    Preview
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Contract Preview */}
+        <div className="p-6 space-y-4 max-h-96 overflow-y-auto">
+          <h3 className="text-lg font-semibold text-gray-800">Contract Summary</h3>
+
+          {/* Contract Info */}
+          <div className="p-4">
+            <div className="text-sm space-y-2">
+              <div className="flex text-lg">
+                <span>Escrow Type:</span>
+                <span className="font-semibold">Goods and Services</span>
+              </div>
+              <div className="flex text-lg">
+                <span>Total Escrow Amount:</span>
+                <span className="font-semibold flex gap-1">
+                  {escrowData?.paymentAmount ? escrowData.paymentAmount.replace(/\B(?=(\d{3})+(?!\d))/g, ",") : "N/A"}
+                  <Image src={usdc} alt="USDC" width={16} height={16} />
+                </span>
+              </div>
+              <div className="flex text-lg">
+                <span>Parties Involved:</span>
+                <span className="font-semibold">{buyer}, Seller {seller}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Payment Info */}
+          <div className="p-4 rounded-md">
+            <h4 className="font-semibold text-lg text-gray-700 mb-2">Milestone Details</h4>
+            <div className="text-sm space-y-2">
+              {escrowData.payment && (
+                <div className="mt-3">
+                  <table className="min-w-full border border-gray-300 rounded">
+                    <thead className="bg-gray-200">
+                      <tr>
+                        <th className="border border-gray-300 px-4 py-2 text-left">Milestone Name</th>
+                        <th className="border border-gray-300 px-4 py-2 text-left">Condition</th>
+                        <th className="border border-gray-300 px-4 py-2 text-left">Percentage</th>
+                        <th className="border border-gray-300 px-4 py-2 text-left">Amount ($)</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {escrowData.payment.percentageBreakdown.map((item, index) => (
+                        <tr key={index} className="border-b border-gray-300">
+                          <td className="border border-gray-300 px-4 py-2">{item.stage}</td>
+                          <td className="border border-gray-300 px-4 py-2">{escrowData.condition?.title || "Not specified"}</td>
+                          <td className="border border-gray-300 px-4 py-2">{item.percentage}%</td>
+                          <td className="border border-gray-300 px-4 py-2">
+                            {((parseFloat(escrowData.paymentAmount || "0") * item.percentage) / 100).toFixed(2)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Terms & Agreements */}
+          <div>
+            <h4 className="font-semibold text-lg text-gray-700 mb-1">Terms & Agreements</h4>
+            <div className="text-base text-gray-600">
+              <p>By signing this contract, both parties agree to the terms and conditions outlined above. Funds will be held in escrow according to the payment structure and released upon completion of the specified milestones and conditions.</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-center gap-[24px] px-6 py-4">
+          <button
+            onClick={onPrevious}
+            className="px-6 py-2 w-[323px] h-[52px] bg-[#2D0561] text-white rounded-[4px] hover:bg-[#2d0561ee] focus:outline-none focus:ring-2 focus:ring-[#D9D9D9] focus:ring-offset-2"
+          >
+            Previous
+          </button>
+          <button
+            onClick={handleConfirm}
+            className="px-6 py-2 w-[323px] h-[52px] bg-[#2D0561] text-white rounded-[4px] hover:bg-[#2d0561ee] focus:outline-none focus:ring-2 focus:ring-[#D9D9D9] focus:ring-offset-2"
+          >
+            Confirm & Sign
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/modal-component/modal-workflow/Workflow.tsx
+++ b/components/modal-component/modal-workflow/Workflow.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import MilestoneModal from "../MilestoneModal";
 import ConditionModal from "../ConditionModal";
 import PaymentModal from "../PaymentModal";
+import PreviewModal from "../PreviewModal";
 
 interface ModalProps {
   onNext?: () => void;
@@ -15,7 +16,7 @@ interface IModalWorkflow {
 }
 const ModalWorkflow: React.FC<IModalWorkflow> = ({ closeModal }) => {
   const [currentStep, setCurrentStep] = useState<
-    "milestone" | "condition" | "payment"
+    "milestone" | "condition" | "payment" | "preview"
   >("milestone");
 
   const handleNextFromMilestone = () => {
@@ -32,6 +33,14 @@ const ModalWorkflow: React.FC<IModalWorkflow> = ({ closeModal }) => {
 
   const handlePreviousFromPayment = () => {
     setCurrentStep("condition");
+  };
+
+  const handleNextFromPayment = () => {
+    setCurrentStep("preview");
+  };
+
+  const handlePreviousFromPreview = () => {
+    setCurrentStep("payment");
   };
 
   return (
@@ -51,7 +60,15 @@ const ModalWorkflow: React.FC<IModalWorkflow> = ({ closeModal }) => {
       {currentStep === "payment" && (
         <PaymentModal
           onPrevious={handlePreviousFromPayment}
-          onNext={() => {}}
+          onNext={handleNextFromPayment}
+        />
+      )}
+
+      {currentStep === "preview" && (
+        <PreviewModal
+          onPrevious={handlePreviousFromPreview}
+          closeModal={closeModal}
+        // onNext={() => {}}
         />
       )}
     </>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "recharts": "^2.15.0",
         "starknet": "^6.11.0",
         "tailwind-merge": "^3.0.1",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -3715,6 +3716,35 @@
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "recharts": "^2.15.0",
     "starknet": "^6.11.0",
     "tailwind-merge": "^3.0.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/store/useEscrowStore.ts
+++ b/store/useEscrowStore.ts
@@ -1,0 +1,200 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface ContractInfo {
+  title: string;
+  startDate: Date | null;
+  endDate: Date | null;
+}
+
+interface Milestone {
+  title: string;
+  description: string;
+}
+
+interface Condition {
+  title: string;
+  customCondition?: string;
+}
+
+interface Payment {
+  amount: string;
+  percentageBreakdown: { stage: string; percentage: number }[];
+  structureDescription: string;
+}
+
+interface EscrowStore {
+  // Data lists
+  milestones: Milestone[];
+  conditions: Condition[];
+  payments: Payment[];
+  
+  // Current selections
+  contractInfo: ContractInfo;
+  selectedMilestone: string;
+  selectedCondition: string;
+  customCondition: string;
+  paymentAmount: string;
+  selectedPaymentStructure: string;
+  
+  // Step completion tracking
+  steps: {
+    milestone: boolean;
+    condition: boolean;
+    payment: boolean;
+    preview: boolean;
+  };
+  
+  // Actions
+  setContractInfo: (info: Partial<ContractInfo>) => void;
+  setSelectedMilestone: (milestone: string) => void;
+  setSelectedCondition: (condition: string) => void;
+  setCustomCondition: (condition: string) => void;
+  setPaymentAmount: (amount: string) => void;
+  setSelectedPaymentStructure: (structure: string) => void;
+  
+  // Step management
+  completeStep: (step: 'milestone' | 'condition' | 'payment' | 'preview') => void;
+  resetStep: (step: 'milestone' | 'condition' | 'payment' | 'preview') => void;
+  
+  // Get complete escrow data for preview
+  getEscrowData: () => {
+    contractInfo: ContractInfo;
+    milestone: Milestone | undefined;
+    condition: Condition | undefined;
+    payment: Payment | undefined;
+    customCondition: string;
+    paymentAmount: string;
+  };
+  
+  // Reset entire store
+  resetStore: () => void;
+}
+
+// Initial state definition
+const initialState = {
+  milestones: [
+    {
+      title: "Goods Purchase",
+      description: "Payment Held in Escrow, Goods Delivered, Buyer Confirms Receipt",
+    },
+    {
+      title: "Freelance Service",
+      description: "Initial Deposit Paid, First Draft Delivered, Revisions Completed, Final Delivery Approved",
+    },
+    {
+      title: "Rental Agreement",
+      description: "Deposit Paid, Keys Delivered, Remaining Rent Paid",
+    },
+    {
+      title: "NFT Purchase",
+      description: "Payment Held in Escrow, Goods Delivered, Buyer Confirms Receipt",
+    },
+  ],
+  conditions: [
+    { title: "Manual approval by both parties." },
+    { title: "Automatic release upon milestone completion." },
+  ],
+  payments: [
+    {
+      amount: "",
+      structureDescription: "50-25-15-10",
+      percentageBreakdown: [
+        { stage: "Initial Deposit Paid", percentage: 50 },
+        { stage: "First Draft Delivered", percentage: 25 },
+        { stage: "Revisions Completed", percentage: 15 },
+        { stage: "Final Delivery Approved", percentage: 10 },
+      ],
+    },
+    {
+      amount: "",
+      structureDescription: "25-25-25-25",
+      percentageBreakdown: [
+        { stage: "Initial Deposit Paid", percentage: 25 },
+        { stage: "First Draft Delivered", percentage: 25 },
+        { stage: "Revisions Completed", percentage: 25 },
+        { stage: "Final Delivery Approved", percentage: 25 },
+      ],
+    },
+    {
+      amount: "",
+      structureDescription: "20-20-20-40",
+      percentageBreakdown: [
+        { stage: "Initial Deposit Paid", percentage: 20 },
+        { stage: "First Draft Delivered", percentage: 20 },
+        { stage: "Revisions Completed", percentage: 20 },
+        { stage: "Final Delivery Approved", percentage: 40 },
+      ],
+    },
+  ],
+  
+  contractInfo: {
+    title: "",
+    startDate: null,
+    endDate: null
+  },
+  selectedMilestone: "",
+  selectedCondition: "",
+  customCondition: "",
+  paymentAmount: "",
+  selectedPaymentStructure: "",
+  
+  steps: {
+    milestone: false,
+    condition: false,
+    payment: false,
+    preview: false
+  }
+};
+
+export const useEscrowStore = create<EscrowStore>()(
+  persist(
+    (set, get) => ({
+      ...initialState,
+      
+      setContractInfo: (info) => set((state) => ({
+        contractInfo: { ...state.contractInfo, ...info }
+      })),
+      
+      setSelectedMilestone: (milestone) => set({ selectedMilestone: milestone }),
+      
+      setSelectedCondition: (condition) => set({ selectedCondition: condition }),
+      
+      setCustomCondition: (condition) => set({ customCondition: condition }),
+      
+      setPaymentAmount: (amount) => set({ paymentAmount: amount }),
+      
+      setSelectedPaymentStructure: (structure) => set({ selectedPaymentStructure: structure }),
+      
+      completeStep: (step) => set((state) => ({
+        steps: { ...state.steps, [step]: true }
+      })),
+      
+      resetStep: (step) => set((state) => ({
+        steps: { ...state.steps, [step]: false }
+      })),
+      
+      getEscrowData: () => {
+        const state = get();
+        return {
+          contractInfo: state.contractInfo,
+          milestone: state.milestones.find(m => m.title === state.selectedMilestone),
+          condition: state.conditions.find(c => c.title === state.selectedCondition),
+          payment: state.payments.find(p => {
+            const structureText = p.percentageBreakdown
+              .map(item => `${item.stage}: ${item.percentage}%`)
+              .join(" - ");
+            return structureText === state.selectedPaymentStructure;
+          }),
+          customCondition: state.customCondition,
+          paymentAmount: state.paymentAmount
+        };
+      },
+      
+      resetStore: () => set(initialState)
+    }),
+    {
+      name: 'escrow-storage'
+    }
+  )
+);


### PR DESCRIPTION
# Pull Request

### In this PR, I

- built the `PreviewModal.jsx` component following the structure and flow from `Workflow.tsx`
- created a `store` folder to store the `useEscrowStore`, and added persistence, which was used in all relating modals to save the state
- clicking the confirm button after preview clears the state in local storage
- ensure to preserve previous functionality

### Operations conducted
- [x] closes #44
- [x] utilises the `useEscrowStore.tsx` from `store` folder
- [x] uses the stepper, maintaining the state change
- [x] persists the data and displays on the screen
- [x] matches the design on the figma